### PR TITLE
Fix import in VerifySignature middleware

### DIFF
--- a/src/Http/Middleware/VerifySignature.php
+++ b/src/Http/Middleware/VerifySignature.php
@@ -5,7 +5,7 @@ namespace Meema\MediaConverter\Http\Middleware;
 use Aws\Sns\Message;
 use Aws\Sns\MessageValidator;
 use Closure;
-use Illuminate\Http\Client\Request;
+use Illuminate\Http\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class VerifySignature


### PR DESCRIPTION
Resolves:
Argument 1 passed to Meema\MediaConverter\Http\Middleware\VerifySignature::handle() must be an instance of Illuminate\Http\Client\Request, instance of Illuminate\Http\Request given, called in /var/app/current/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php on line 167