### PR TITLE
Read account url from config instead of sending a http request to AWS…

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Next, please add the following keys their values to your `.env` file.
 AWS_ACCESS_KEY_ID=xxxxxxx
 AWS_SECRET_ACCESS_KEY=xxxxxxx
 AWS_DEFAULT_REGION=us-east-1
+AWS_MEDIA_CONVERT_ACCOUNT_URL=https://xxxxxxxxx.mediaconvert.us-east-1.amazonaws.com
 AWS_IAM_ARN=arn:aws:iam::xxxxxxx:role/MediaConvert_Default_Role
 AWS_QUEUE_ARN=arn:aws:mediaconvert:us-east-1:xxxxxxx:queues/Default
 ```
@@ -70,9 +71,9 @@ return [
         'key' => env('AWS_ACCESS_KEY_ID'),
         'secret' => env('AWS_SECRET_ACCESS_KEY'),
     ],
-
     'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
     'version' => 'latest',
+    'url' => env('AWS_MEDIA_CONVERT_ACCOUNT_URL'),
 
     /**
      * Specify the IAM Role ARN.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Next, please add the following keys their values to your `.env` file.
 AWS_ACCESS_KEY_ID=xxxxxxx
 AWS_SECRET_ACCESS_KEY=xxxxxxx
 AWS_DEFAULT_REGION=us-east-1
-AWS_MEDIA_CONVERT_ACCOUNT_URL=https://xxxxxxxxx.mediaconvert.us-east-1.amazonaws.com
+AWS_MEDIACONVERT_ACCOUNT_URL=https://xxxxxxxxx.mediaconvert.us-east-1.amazonaws.com
 AWS_IAM_ARN=arn:aws:iam::xxxxxxx:role/MediaConvert_Default_Role
 AWS_QUEUE_ARN=arn:aws:mediaconvert:us-east-1:xxxxxxx:queues/Default
 ```
@@ -73,7 +73,7 @@ return [
     ],
     'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
     'version' => 'latest',
-    'url' => env('AWS_MEDIA_CONVERT_ACCOUNT_URL'),
+    'url' => env('AWS_MEDIACONVERT_ACCOUNT_URL'),
 
     /**
      * Specify the IAM Role ARN.

--- a/config/config.php
+++ b/config/config.php
@@ -13,9 +13,9 @@ return [
         'key' => env('AWS_ACCESS_KEY_ID'),
         'secret' => env('AWS_SECRET_ACCESS_KEY'),
     ],
-
     'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
     'version' => 'latest',
+    'url' => env('AWS_MEDIA_CONVERT_ACCOUNT_URL'),
 
     /**
      * Specify the IAM Role ARN.

--- a/config/config.php
+++ b/config/config.php
@@ -15,7 +15,7 @@ return [
     ],
     'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
     'version' => 'latest',
-    'url' => env('AWS_MEDIA_CONVERT_ACCOUNT_URL'),
+    'url' => env('AWS_MEDIACONVERT_ACCOUNT_URL'),
 
     /**
      * Specify the IAM Role ARN.

--- a/src/Converters/MediaConverter.php
+++ b/src/Converters/MediaConverter.php
@@ -22,14 +22,13 @@ class MediaConverter implements Converter
      */
     public function __construct(MediaConvertClient $client)
     {
-        $result = $client->describeEndpoints([]);
         $config = config('media-converter');
 
         $this->client = new MediaConvertClient([
             'version' => $config['version'],
             'region' => $config['region'],
             'credentials' => new Credentials($config['credentials']['key'], $config['credentials']['secret']),
-            'endpoint' => $result['Endpoints'][0]['Url'],
+            'endpoint' => $config['url'],
         ]);
     }
 


### PR DESCRIPTION
Read the MediaConvert account url from config, instead of sending a http request to AWS to get this url for every job. 

The describeEndpoints() has quite a low rate limit, hence multiple users uploading files at the same time, or a single user uploading > 5 files will trigger a 
`429 Too Many Requests`
error from AWS.

This endpoint doesn't change for an account, hence AWS recommends requesting it only once and caching it.
https://docs.amazonaws.cn/en_us/mediaconvert/latest/apireference/custom-endpoints.html

It's fairly easy to get this account url
1. Via the console
`https://console.aws.amazon.com/mediaconvert/home?#/account`

2. Via AWS CLi
`aws mediaconvert describe-endpoints`

Cheers, hope it's helpful, thanks again.