### PR TITLE
fix: changed incorrect publish command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The package will automatically register itself.
 Next, publish the config file with:
 
 ```bash
-php artisan vendor:publish --provider="Meema\MediaConverter\Providers\MediaConvertServiceProvider" --tag="config"
+php artisan vendor:publish --provider="Meema\MediaConverter\Providers\MediaConverterServiceProvider" --tag="config"
 ```
 
 Next, please add the following keys their values to your `.env` file.


### PR DESCRIPTION
The specified publish command fails with the message _Unable to locate publishable resources._. This is due to the commmand containing the wrong path for the MediaConverterServiceProvider